### PR TITLE
Don't "connect" the UDP socket.

### DIFF
--- a/lib/gelf/transport/udp.rb
+++ b/lib/gelf/transport/udp.rb
@@ -31,12 +31,11 @@ module GELF
       def create_consumer_for host, port
         Thread.new do
           socket = UDPSocket.new(Addrinfo.ip(host).afamily)
-          socket.connect(host, port)
 
           loop do
             datagram = @q.pop
             break unless datagram
-            socket.send(datagram, 0)
+            socket.send(datagram, 0, host, port)
           end
         end
       end


### PR DESCRIPTION
Establishing a "connection" for UDP means that on Linux the underlying socket will deal with ICMP responses about undelivered packages.

The connection gets marked as "closed" by the OS after an "unreachable" ICMP message for the source port arrives.

From what I can tell there is not too much of a performance win for calling connect() except that every packet will have a different source port (at least on 18.04 Bionic Beaver).